### PR TITLE
Add API endpoint for listing tool connections

### DIFF
--- a/app/controllers/tool_connections_controller.rb
+++ b/app/controllers/tool_connections_controller.rb
@@ -1,0 +1,10 @@
+class ToolConnectionsController < ApplicationController
+  def index
+    membership_ids = @current_user.organization_memberships.pluck(:id)
+    @tool_connections = ToolConnection
+      .where(organization_membership_id: membership_ids)
+      .order(updated_at: :desc)
+
+    render json: { data: @tool_connections.map(&:as_json) }
+  end
+end

--- a/app/models/concerns/uuid_primary_key.rb
+++ b/app/models/concerns/uuid_primary_key.rb
@@ -1,0 +1,13 @@
+module UuidPrimaryKey
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :assign_uuid, on: :create
+  end
+
+  private
+
+  def assign_uuid
+    self.id ||= SecureRandom.uuid
+  end
+end

--- a/app/models/organization_membership.rb
+++ b/app/models/organization_membership.rb
@@ -1,0 +1,6 @@
+class OrganizationMembership < ApplicationRecord
+  include UuidPrimaryKey
+
+  belongs_to :user
+  has_many :tool_connections, dependent: :destroy
+end

--- a/app/models/tool_connection.rb
+++ b/app/models/tool_connection.rb
@@ -1,0 +1,30 @@
+class ToolConnection < ApplicationRecord
+  include UuidPrimaryKey
+
+  belongs_to :organization_membership
+
+  validates :tool_name, :connection_state, :scope, presence: true
+  validates :tool_name, uniqueness: { scope: :organization_membership_id }
+
+  def token_expired?
+    token_expires_at.present? && token_expires_at < Time.current
+  end
+
+  def as_json(_options = {})
+    {
+      id: id,
+      toolName: tool_name,
+      connectionState: connection_state,
+      externalUserId: external_user_id,
+      externalUsername: external_username,
+      externalEmail: external_email,
+      createdAt: created_at&.utc&.iso8601,
+      updatedAt: updated_at&.utc&.iso8601,
+      tokenExpiresAt: token_expires_at&.utc&.iso8601,
+      organizationMembershipId: organization_membership_id,
+      tokenExpired: token_expired?,
+      scope: scope,
+      lastUsedAt: last_used_at&.utc&.iso8601
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ApplicationRecord
 
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :organization_memberships, dependent: :destroy
+  has_many :tool_connections, through: :organization_memberships
 
   def does_follow_another_user(user)
     following.include?(user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,7 @@ Rails.application.routes.draw do
     end
 
     resources :tags, only: :index
+
+    resources :tool_connections, only: :index
   end
 end

--- a/db/migrate/20260610120000_create_organization_memberships.rb
+++ b/db/migrate/20260610120000_create_organization_memberships.rb
@@ -1,0 +1,10 @@
+class CreateOrganizationMemberships < ActiveRecord::Migration[7.0]
+  def change
+    create_table :organization_memberships, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260610120001_create_tool_connections.rb
+++ b/db/migrate/20260610120001_create_tool_connections.rb
@@ -1,0 +1,22 @@
+class CreateToolConnections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :tool_connections, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.string :tool_name, null: false
+      t.string :connection_state, null: false, default: 'active'
+      t.string :external_user_id
+      t.string :external_username
+      t.string :external_email
+      t.datetime :token_expires_at
+      t.string :organization_membership_id, null: false
+      t.string :scope, null: false, default: 'persona'
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :tool_connections, :organization_membership_id
+    add_index :tool_connections, [:organization_membership_id, :tool_name], unique: true, name: 'index_tool_connections_on_membership_and_tool'
+    add_foreign_key :tool_connections, :organization_memberships, column: :organization_membership_id, primary_key: :id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_035813) do
+ActiveRecord::Schema[7.0].define(version: 2026_06_10_120001) do
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.string "slug"
@@ -52,11 +52,34 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_035813) do
     t.index ["following_id"], name: "index_followers_on_following_id"
   end
 
+  create_table "organization_memberships", id: :string, force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_organization_memberships_on_user_id"
+  end
+
   create_table "tags", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  create_table "tool_connections", id: :string, force: :cascade do |t|
+    t.string "tool_name", null: false
+    t.string "connection_state", default: "active", null: false
+    t.string "external_user_id"
+    t.string "external_username"
+    t.string "external_email"
+    t.datetime "token_expires_at"
+    t.string "organization_membership_id", null: false
+    t.string "scope", default: "persona", null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_membership_id", "tool_name"], name: "index_tool_connections_on_membership_and_tool", unique: true
+    t.index ["organization_membership_id"], name: "index_tool_connections_on_organization_membership_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -74,4 +97,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_035813) do
   add_foreign_key "articles", "users"
   add_foreign_key "comments", "articles"
   add_foreign_key "comments", "users"
+  add_foreign_key "organization_memberships", "users"
+  add_foreign_key "tool_connections", "organization_memberships"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,3 +3,24 @@ User.create([
   { username: "Steve", email: "steve@email.com", password: "secret" },
   { username: "Jenna", email: "jenna@email.com", password: "secret" }
 ])
+
+membership = OrganizationMembership.create!(id: "accbfcf6-c928-43f7-8456-ce6e6ebaa0ab", user: User.first)
+
+ToolConnection.create!([
+  {
+    id: "48120e78-4628-4d04-83fb-8998cdc404b9",
+    tool_name: "claude_code",
+    connection_state: "active",
+    organization_membership: membership,
+    scope: "persona",
+    last_used_at: Time.utc(2026, 6, 10, 12, 53, 24)
+  },
+  {
+    id: "436ddb80-e340-4c9b-9c69-fe9b14a0609f",
+    tool_name: "cursor",
+    connection_state: "active",
+    organization_membership: membership,
+    scope: "persona",
+    last_used_at: Time.utc(2026, 6, 10, 0, 0, 0)
+  }
+])

--- a/test/controllers/tool_connections_controller_test.rb
+++ b/test/controllers/tool_connections_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ToolConnectionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @token = JsonWebToken.encode(user_id: @user.id)
+    @headers = { Authorization: @token }
+  end
+
+  test "should get index" do
+    get '/api/tool_connections', headers: @headers, as: :json
+
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert body.key?("data")
+    assert_equal 2, body["data"].length
+
+    tool_names = body["data"].map { |connection| connection["toolName"] }
+    assert_includes tool_names, "claude_code"
+    assert_includes tool_names, "cursor"
+
+    claude_connection = body["data"].find { |connection| connection["toolName"] == "claude_code" }
+    assert_equal "48120e78-4628-4d04-83fb-8998cdc404b9", claude_connection["id"]
+    assert_equal "active", claude_connection["connectionState"]
+    assert_equal "accbfcf6-c928-43f7-8456-ce6e6ebaa0ab", claude_connection["organizationMembershipId"]
+    assert_equal false, claude_connection["tokenExpired"]
+    assert_equal "persona", claude_connection["scope"]
+  end
+
+  test "should require authentication" do
+    get '/api/tool_connections', as: :json
+
+    assert_response :unauthorized
+  end
+end

--- a/test/fixtures/organization_memberships.yml
+++ b/test/fixtures/organization_memberships.yml
@@ -1,0 +1,3 @@
+one:
+  id: accbfcf6-c928-43f7-8456-ce6e6ebaa0ab
+  user: one

--- a/test/fixtures/tool_connections.yml
+++ b/test/fixtures/tool_connections.yml
@@ -1,0 +1,23 @@
+claude_code:
+  id: 48120e78-4628-4d04-83fb-8998cdc404b9
+  tool_name: claude_code
+  connection_state: active
+  external_user_id:
+  external_username:
+  external_email:
+  token_expires_at:
+  organization_membership_id: accbfcf6-c928-43f7-8456-ce6e6ebaa0ab
+  scope: persona
+  last_used_at: 2026-06-10 12:53:24 UTC
+
+cursor:
+  id: 436ddb80-e340-4c9b-9c69-fe9b14a0609f
+  tool_name: cursor
+  connection_state: active
+  external_user_id:
+  external_username:
+  external_email:
+  token_expires_at:
+  organization_membership_id: accbfcf6-c928-43f7-8456-ce6e6ebaa0ab
+  scope: persona
+  last_used_at: 2026-06-10 00:00:00 UTC


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new authenticated API endpoint `GET /api/tool_connections` that returns tool connection data in the requested JSON format.

## Changes

- Added `OrganizationMembership` and `ToolConnection` models with UUID primary keys
- Added database migrations for `organization_memberships` and `tool_connections` tables
- Added `ToolConnectionsController#index` returning `{ data: [...] }` with camelCase fields
- Added seeds with sample `claude_code` and `cursor` connections
- Added controller tests covering authenticated access and unauthorized requests

## API

**Endpoint:** `GET /api/tool_connections`

**Auth:** JWT token in `Authorization` header (same as existing endpoints)

**Response example:**

```json
{
  "data": [
    {
      "id": "48120e78-4628-4d04-83fb-8998cdc404b9",
      "toolName": "claude_code",
      "connectionState": "active",
      "externalUserId": null,
      "externalUsername": null,
      "externalEmail": null,
      "createdAt": "2026-06-10T12:56:18Z",
      "updatedAt": "2026-06-10T12:57:35Z",
      "tokenExpiresAt": null,
      "organizationMembershipId": "accbfcf6-c928-43f7-8456-ce6e6ebaa0ab",
      "tokenExpired": false,
      "scope": "persona",
      "lastUsedAt": "2026-06-10T12:53:24Z"
    }
  ]
}
```

## Test plan

- [x] `bundle exec rails test test/controllers/tool_connections_controller_test.rb`
- [ ] Run `bin/rails db:migrate db:seed` and verify `GET /api/tool_connections` with a valid JWT
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de24e707-7ea4-4a9c-86eb-fcc402ef1c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de24e707-7ea4-4a9c-86eb-fcc402ef1c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

